### PR TITLE
HW2 found 2 bugs, making PR

### DIFF
--- a/src/main/java/edu/studyup/serviceImpl/EventServiceImpl.java
+++ b/src/main/java/edu/studyup/serviceImpl/EventServiceImpl.java
@@ -34,10 +34,15 @@ public class EventServiceImpl implements EventService {
 		Map<Integer, Event> eventData = DataStorage.eventData;
 		List<Event> activeEvents = new ArrayList<>();
 		
-		for (Integer key : eventData.keySet()) {
-			Event ithEvent= eventData.get(key);
+		// Iterate over events, not the event keys
+		for (Event ithEvent : eventData.values()) {
 			activeEvents.add(ithEvent);
 		}
+		
+//		for (Integer key : eventData.keySet()) {
+//			Event ithEvent= eventData.get(key);
+//			activeEvents.add(ithEvent);
+//		}
 		return activeEvents;
 	}
 
@@ -46,13 +51,22 @@ public class EventServiceImpl implements EventService {
 		Map<Integer, Event> eventData = DataStorage.eventData;
 		List<Event> pastEvents = new ArrayList<>();
 		
-		for (Integer key : eventData.keySet()) {
-			Event ithEvent= eventData.get(key);
-			// Checks if an event date is before today, if yes, then add to the past event list.
+		
+		// Iterate over events, not the event keys
+		for (Event ithEvent : eventData.values()) {
 			if(ithEvent.getDate().before(new Date())) {
 				pastEvents.add(ithEvent);
 			}
 		}
+		
+//		for (Integer key : eventData.keySet()) {
+//			Event ithEvent= eventData.get(key);
+//			// Checks if an event date is before today, if yes, then add to the past event list.
+//			if(ithEvent.getDate().before(new Date())) {
+//				pastEvents.add(ithEvent);
+//			}
+//		}
+		
 		return pastEvents;
 	}
 


### PR DESCRIPTION
There were 2 bugs I found. In getActiveEvents() there was a for loop which iterated over each event key, then called the .get on the key to retrieve the event. This is less efficient than just looping over the events in the map initially. In the function getPastEvents() there was a similar thing to find past events where they looped over keys, grabbed the event, and then checked if it was past. Now they loop over the events and are able to just check if the event is passed without grabbing the event from the map.